### PR TITLE
MGMT-1180 - fix the build of install-image: store the original ISO in…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM quay.io/yshnaidm/livecd-iso:fedora-coreos-livecd
+
 FROM python:2.7
 
 ARG WORK_DIR=/data
@@ -5,10 +7,9 @@ ARG WORK_DIR=/data
 RUN mkdir $WORK_DIR
 RUN chmod 777 $WORK_DIR
 
-ARG COREOS_IMAGE
-COPY ./$COREOS_IMAGE $WORK_DIR
-RUN chmod 666 $WORK_DIR/$COREOS_IMAGE
-ENV COREOS_IMAGE=$WORK_DIR/$COREOS_IMAGE
+COPY --from=0 /root/image/livecd.iso $WORK_DIR
+RUN chmod 666 $WORK_DIR/livecd.iso
+ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
 
 COPY ./coreos-installer $WORK_DIR
 COPY ./install_process.py $WORK_DIR

--- a/Dockerfile.livecd-iso-image
+++ b/Dockerfile.livecd-iso-image
@@ -1,0 +1,3 @@
+FROM alpine:latest
+RUN mkdir /root/image
+COPY ./fedora-coreos-31.20200319.dev.1-live.x86_64.iso /root/image/livecd.iso

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 This image is a tool to create a coreOS image with a passed ignition file.
 The output of the container is a ISO live CD image that will be uploaded to s3 of your choice.
 
+Building an livecd image:
+* use Dockerfile.livecd-iso-image to create an container image that will store the LIVECD ISO that we are going to use. Pushed to some accessible repository
+
 Building a builder image:
-* Update the COREOS IMAGE in the Docker file to the coreOS live CD ISO of you'r choice
+* in the Dockerfile , update the first line to point to the LIVECD ISO image that you want to use ( the one you built in the previous stage)
 * Build the docker image and push to you registry
 
 ### Using the image:


### PR DESCRIPTION
… a container of its own, and use it to copy the ISO into image-installer.No need to use COREOS_IMAGE env anymore